### PR TITLE
RunKit live demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## <img width=2% src="https://scribbletune.com/images/scribbletune-logo.png"> SCRIBBLETUNE
 
 [![Build Status](https://travis-ci.com/scribbletune/scribbletune.svg?branch=master)](http://travis-ci.com/scribbletune/scribbletune)
+[![Try scribbletune on RunKit](https://badge.runkitcdn.com/scribbletune.svg)](https://npm.runkit.com/scribbletune)
 
 Use simple **JavaScript** `Strings` and `Arrays` to generate rhythms and musical patterns. Directly use the names of scales or chords in your code to get arrays which you can mash up using Array methods in ways you hadn't imagined before! Create clips of musical ideas and **export MIDI files** which you can import in _Ableton Live, Reason, Garage Band_ or any music creation software that accepts MIDI files.
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   ],
   "author": "Walmik Deshpande",
   "license": "MIT",
+  "runkitExampleFilename": "runkit.js",
   "bugs": {
     "url": "https://github.com/scribbletune/scribbletune/issues"
   },

--- a/runkit.js
+++ b/runkit.js
@@ -1,0 +1,9 @@
+const rkmidi = require('runkit-midi');
+const scribble = require('scribbletune');
+
+const clip = scribble.clip({
+  notes: scribble.scale('C4 major'),
+  pattern: 'xxxxxxx'
+});
+
+rkmidi(scribble.midi(clip, null));


### PR DESCRIPTION
# Description
This commit enables the RunKit live demo on the [>_ Try on RunKit] button on the project's NPM page:
https://runkit.com/embed/we2zfbtht7e4
Visitors will be able to play and view the contents of MIDI files generated by scribbletune

# Previews
![scribbletune](https://user-images.githubusercontent.com/8745429/109408796-e15e4000-795a-11eb-9559-3f0a01052e24.png)

# CheckLists
- [N/A] Add Labels
- [N/A] Unit Testing
